### PR TITLE
Add missing `shell` reference for the `publish:release-notes` step of `action.yml`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 1.0.3
+
+- Add missing `shell` reference for the `publish:release-notes` step of `action.yml`
+
 ## 1.0.2
 
 - Removed invalid reference in `action.yml`

--- a/action.yml
+++ b/action.yml
@@ -39,5 +39,6 @@ runs:
 
     # Task execution
     - run: npm run publish:release-notes
+      shell: bash
       env:
         GITHUB_TOKEN: ${{ inputs.github_token }}

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "simple-release-notes-action",
-  "version": "1.0.2",
+  "version": "1.0.3",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "simple-release-notes-action",
-      "version": "1.0.2",
+      "version": "1.0.3",
       "license": "MIT",
       "dependencies": {
         "@octokit/action": "3.18.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "simple-release-notes-action",
-  "version": "1.0.2",
+  "version": "1.0.3",
   "author": "Eric L. Goldstein",
   "description": "GitHub Action that auto-publishes release notes using a very simple-to-follow set of rules",
   "keywords": [


### PR DESCRIPTION
- Version bump to `1.0.3`
- Add missing `shell` reference for the `publish:release-notes` step of `action.yml`