### PR TITLE
Correctly pass GitHub auth token to this action so it can publish

### DIFF
--- a/.github/workflows/publishReleaseNotesWorkflow.yml
+++ b/.github/workflows/publishReleaseNotesWorkflow.yml
@@ -15,5 +15,5 @@ jobs:
       # Task execution
       - name: Run mangs/simple-release-notes-action
         uses: ./
-        env:
-          INPUT_GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 1.1.2
+
+- Correctly pass GitHub auth token to this action so it can publish
+
 ## 1.1.1
 
 - Fix inability to match target version number

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "simple-release-notes-action",
-  "version": "1.1.1",
+  "version": "1.1.2",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "simple-release-notes-action",
-      "version": "1.1.1",
+      "version": "1.1.2",
       "license": "MIT",
       "devDependencies": {
         "@vscode/ripgrep": "1.14.2",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "simple-release-notes-action",
-  "version": "1.1.1",
+  "version": "1.1.2",
   "author": "Eric L. Goldstein",
   "description": "GitHub Action that auto-publishes release notes using a very simple-to-follow set of rules",
   "keywords": [


### PR DESCRIPTION
- Version bump to `1.1.2`
- Correctly pass GitHub auth token to this action so it can publish