### PR TITLE
Properly handle the default case where `tag_override` is an empty string

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 1.1.3
+
+- Properly handle the default case where `tag_override` is an empty string
+
 ## 1.1.2
 
 - Correctly pass GitHub auth token to this action so it can publish

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "simple-release-notes-action",
-  "version": "1.1.2",
+  "version": "1.1.3",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "simple-release-notes-action",
-      "version": "1.1.2",
+      "version": "1.1.3",
       "license": "MIT",
       "devDependencies": {
         "@vscode/ripgrep": "1.14.2",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "simple-release-notes-action",
-  "version": "1.1.2",
+  "version": "1.1.3",
   "author": "Eric L. Goldstein",
   "description": "GitHub Action that auto-publishes release notes using a very simple-to-follow set of rules",
   "keywords": [

--- a/scripts/publishReleaseNotes.mjs
+++ b/scripts/publishReleaseNotes.mjs
@@ -100,7 +100,7 @@ async function main() {
   // Prepare metadata
   const repositoryMetadata = process.env.GITHUB_REPOSITORY.split('/');
   const [repoOwner, repoName] = repositoryMetadata;
-  const tagName = tagOverride ?? `${tagPrefix}${targetVersion}`;
+  const tagName = tagOverride || `${tagPrefix}${targetVersion}`;
   const commitHash = process.env.GITHUB_SHA;
   // const isDraft = false;
   // const isPrerelease = false;


### PR DESCRIPTION
- Version bump to `1.1.3`
- Properly handle the default case where `tag_override` is an empty string