### PR TITLE
Release title remove link markup

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 2.1.0
+
+- For release note titles, replace link markup with just the link's user-visible text
+
 ## 2.0.0
 
 - Support SemVer patch version matching of non-numeric characters following [SemVer formatting rules](https://semver.org/#semantic-versioning-specification-semver) (e.g. `1.2.3-alpha.7+secret-release`)

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "simple-release-notes-action",
-  "version": "2.0.0",
+  "version": "2.1.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "simple-release-notes-action",
-      "version": "2.0.0",
+      "version": "2.1.0",
       "license": "MIT",
       "devDependencies": {
         "@vscode/ripgrep": "1.14.2",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "simple-release-notes-action",
-  "version": "2.0.0",
+  "version": "2.1.0",
   "author": "Eric L. Goldstein",
   "description": "GitHub Action that auto-publishes release notes using a very simple-to-follow set of rules",
   "keywords": [

--- a/scripts/publishReleaseNotes.mjs
+++ b/scripts/publishReleaseNotes.mjs
@@ -13,7 +13,7 @@ const githubToken = process.env.INPUT_GITHUB_TOKEN;
 const packageJsonPath = process.env.INPUT_PACKAGEJSON_PATH ?? './package.json';
 const tagOverride = process.env.INPUT_TAG_OVERRIDE;
 const tagPrefix = process.env.INPUT_TAG_PREFIX ?? 'v';
-const urlRegex = /\[(?<linkText>[^\]]*)\]\([^)]+\)/g;
+const urlRegex = /\[(?<linkText>[^\]]*)\]\([^)]+\)/g; // eslint-disable-line unicorn/better-regex -- stuck in a lint error loop, this is as good as it can get
 const versionMatchRegex =
   // eslint-disable-next-line regexp/no-unused-capturing-group -- having version number parts broken out may be useful in the future
   /(0|[1-9]\d*)\.(0|[1-9]\d*)\.(0|[1-9]\d*)(?:-((?:0|[1-9]\d*|\d*[A-Za-z-][\dA-Za-z-]*)(?:\.(?:0|[1-9]\d*|\d*[A-Za-z-][\dA-Za-z-]*))*))?(?:\+([\dA-Za-z-]+(?:\.[\dA-Za-z-]+)*))?/;

--- a/scripts/publishReleaseNotes.mjs
+++ b/scripts/publishReleaseNotes.mjs
@@ -13,7 +13,7 @@ const githubToken = process.env.INPUT_GITHUB_TOKEN;
 const packageJsonPath = process.env.INPUT_PACKAGEJSON_PATH ?? './package.json';
 const tagOverride = process.env.INPUT_TAG_OVERRIDE;
 const tagPrefix = process.env.INPUT_TAG_PREFIX ?? 'v';
-const urlRegex = /\[(?<linkText>[^\]]*)\]\([^\)]+\)/;
+const urlRegex = /\[(?<linkText>[^\]]*)\]\([^)]+\)/g;
 const versionMatchRegex =
   // eslint-disable-next-line regexp/no-unused-capturing-group -- having version number parts broken out may be useful in the future
   /(0|[1-9]\d*)\.(0|[1-9]\d*)\.(0|[1-9]\d*)(?:-((?:0|[1-9]\d*|\d*[A-Za-z-][\dA-Za-z-]*)(?:\.(?:0|[1-9]\d*|\d*[A-Za-z-][\dA-Za-z-]*))*))?(?:\+([\dA-Za-z-]+(?:\.[\dA-Za-z-]+)*))?/;
@@ -83,7 +83,7 @@ async function main() {
     ) {
       isCapturing = true;
       targetNodeDepth = token.depth;
-      versionMatchHeadingText = token.text.trim();
+      versionMatchHeadingText = token.text.trim().replaceAll(urlRegex, (...a) => a[4].linkText);
     }
   }
   if (!isCapturing) {

--- a/scripts/publishReleaseNotes.mjs
+++ b/scripts/publishReleaseNotes.mjs
@@ -13,6 +13,7 @@ const githubToken = process.env.INPUT_GITHUB_TOKEN;
 const packageJsonPath = process.env.INPUT_PACKAGEJSON_PATH ?? './package.json';
 const tagOverride = process.env.INPUT_TAG_OVERRIDE;
 const tagPrefix = process.env.INPUT_TAG_PREFIX ?? 'v';
+const urlRegex = /\[(?<linkText>[^\]]*)\]\([^\)]+\)/;
 const versionMatchRegex =
   // eslint-disable-next-line regexp/no-unused-capturing-group -- having version number parts broken out may be useful in the future
   /(0|[1-9]\d*)\.(0|[1-9]\d*)\.(0|[1-9]\d*)(?:-((?:0|[1-9]\d*|\d*[A-Za-z-][\dA-Za-z-]*)(?:\.(?:0|[1-9]\d*|\d*[A-Za-z-][\dA-Za-z-]*))*))?(?:\+([\dA-Za-z-]+(?:\.[\dA-Za-z-]+)*))?/;


### PR DESCRIPTION
- Version bump to `2.1.0`
- For release note titles, replace link markup with just the link's user-visible text